### PR TITLE
Add headers to response

### DIFF
--- a/lib/moxinet/plug/mocked_response.ex
+++ b/lib/moxinet/plug/mocked_response.ex
@@ -80,6 +80,7 @@ defmodule Moxinet.Plug.MockedResponse do
 
     conn
     |> put_response_status(response)
+    |> put_response_headers(response)
     |> put_response_body(response)
   end
 
@@ -115,6 +116,12 @@ defmodule Moxinet.Plug.MockedResponse do
 
   defp put_response_status(%Plug.Conn{} = conn, %Response{status: status}) do
     Plug.Conn.put_status(conn, status)
+  end
+
+  defp put_response_headers(%Plug.Conn{} = conn, %Response{headers: headers}) do
+    Enum.reduce(headers, conn, fn {header, value}, acc ->
+      Plug.Conn.put_resp_header(acc, header, value)
+    end)
   end
 
   defp put_response_body(%Plug.Conn{} = conn, %Response{body: body}) do

--- a/lib/moxinet/response.ex
+++ b/lib/moxinet/response.ex
@@ -5,8 +5,9 @@ defmodule Moxinet.Response do
 
   @type t :: %__MODULE__{
           status: 100..600,
+          headers: %{binary() => binary()} | [{binary(), binary()}],
           body: binary() | map() | [any()]
         }
 
-  defstruct status: 200, body: ""
+  defstruct status: 200, headers: [], body: ""
 end

--- a/test/moxinet/mock_test.exs
+++ b/test/moxinet/mock_test.exs
@@ -27,11 +27,16 @@ defmodule Moxinet.MockTest do
         MyMock.expect(
           :post,
           "/path",
-          fn _payload -> %Response{status: 499, body: "My body"} end,
+          fn _payload ->
+            %Response{status: 499, headers: %{"my-header" => "my value"}, body: "My body"}
+          end,
           pid: self()
         )
 
-      assert %Plug.Conn{status: 499, resp_body: "My body"} = MyMock.call(conn, [])
+      assert %Plug.Conn{status: 499, resp_body: "My body", resp_headers: resp_headers} =
+               MyMock.call(conn, [])
+
+      assert {"my-header", "my value"} in resp_headers
     end
 
     test "links the mocked responses to requests made in child processes" do

--- a/test/moxinet/plug/mocked_response_test.exs
+++ b/test/moxinet/plug/mocked_response_test.exs
@@ -24,6 +24,7 @@ defmodule Moxinet.Plug.MockedResponseTest do
 
   describe "call/2" do
     test "responds with applied signature and halts the conn" do
+      response_headers = [{"header1", "value1"}, {"header2", "value2"}]
       response_body = %{response: "yes"}
 
       conn =
@@ -32,7 +33,7 @@ defmodule Moxinet.Plug.MockedResponseTest do
         |> put_req_header("accept", "application/json")
 
       SignatureStorage.store(CustomAPIMock, :get, "/path", fn _payload ->
-        %Response{status: 200, body: response_body}
+        %Response{status: 200, headers: response_headers, body: response_body}
       end)
 
       conn = MockedResponse.call(conn, @opts)
@@ -40,6 +41,7 @@ defmodule Moxinet.Plug.MockedResponseTest do
       assert :sent == conn.state
       assert 200 == conn.status
       assert conn.resp_body == Jason.encode!(response_body)
+      Enum.each(response_headers, &assert(&1 in conn.resp_headers))
     end
 
     test "considers query params to be part of path" do

--- a/test/moxinet/response_test.exs
+++ b/test/moxinet/response_test.exs
@@ -4,8 +4,8 @@ defmodule Moxinet.ResponseTest do
   alias Moxinet.Response
 
   describe "__struct__/1" do
-    test "defaults to `%{status: 200, body: ~s()}`" do
-      assert %Response{status: 200, body: ""} == struct!(Response, %{})
+    test "defaults to `%{status: 200, headers: [], body: ~s()}`" do
+      assert %Response{status: 200, headers: [], body: ""} == struct!(Response, %{})
     end
   end
 end

--- a/test/moxinet/server_test.exs
+++ b/test/moxinet/server_test.exs
@@ -22,15 +22,17 @@ defmodule Moxinet.ServerTest do
       _ = SignatureStorage.start_link(name: SignatureStorage)
 
       Mock.expect(:get, "/mocked_path", fn _payload ->
-        %Response{status: 418, body: "Hello world"}
+        %Response{status: 418, headers: %{"hello-world" => "hi again"}, body: "Hello world"}
       end)
 
       conn =
         conn(:get, "/external_service/mocked_path")
         |> put_req_header("x-moxinet-ref", Moxinet.pid_reference(self()))
 
-      assert %Plug.Conn{status: 418, resp_body: "Hello world"} =
+      assert %Plug.Conn{status: 418, resp_body: "Hello world", resp_headers: resp_headers} =
                MockServer.call(conn, MockServer.init([]))
+
+      assert {"hello-world", "hi again"} in resp_headers
     end
   end
 end


### PR DESCRIPTION
Background:
Some APIs rely on sending data via response headers. This kind of API is not currently perfectly mockable by moxinet due to not supporting mocking response headers.
This PR adds support for mocking response headers to extend support for APIs relying on headers.